### PR TITLE
The bug about the -and and -or

### DIFF
--- a/eg/bug_prefix.pl
+++ b/eg/bug_prefix.pl
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use feature ":5.10";
+use Data::Dumper::Concise;
+use Search::Query;
+
+say '--> Dialect::Native';
+say (
+    Search::Query->parser(
+        default_field => [qw( name email )],
+        fields        => [qw( name email )],
+    )->parse('o')
+);
+
+say '--> Dialect::SQL';
+say (
+    Search::Query->parser(
+        dialect       => 'SQL',
+        default_field => [qw( name email )],
+        fields        => [qw( name email )],
+    )->parse('o')
+);
+
+say '--> Dialect::DBIxClass';
+say Dumper(
+    Search::Query->parser(
+        dialect       => 'DBIxClass',
+        default_field => [qw( name email )],
+        fields        => [qw( name email )],
+    )->parse('o')->as_dbic_query
+);

--- a/lib/Search/Query/Dialect/DBIxClass.pm
+++ b/lib/Search/Query/Dialect/DBIxClass.pm
@@ -161,7 +161,8 @@ sub as_dbic_query {
         : @{ $self->parser->{default_field} };
 
     my @q;
-    foreach my $prefix ( '+', '-' ) {
+    my $mandatory = 0;
+    foreach my $prefix ( '+', '', '-' ) {
         next unless exists $tree->{$prefix};
 
         for my $clause ( @{ $tree->{$prefix} } ) {
@@ -179,10 +180,11 @@ sub as_dbic_query {
                 $self->_dbic_op( $clause, $clause_prefix, \@colnames );
 
             push @q, $dbic_op;
+            $mandatory = 1 if $prefix eq '+' or $prefix eq '-';
         }
     }
 
-    my %search_params = ( -and => \@q );
+    my %search_params = ( ($mandatory ? '-and' : '-or') => \@q );
 
     return \%search_params;
 }

--- a/t/bug_prefix.t
+++ b/t/bug_prefix.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::DBIx::Class qw(:resultsets);
+use Search::Query;
+
+use Data::Dumper::Concise;
+
+fixtures_ok 'core' => 'installed the core fixtures from configuration files';
+
+my @cases = ( [], [qw(name email)] );
+for (@cases) {
+    ok( my $parser = Search::Query->parser(
+            dialect        => 'DBIxClass',
+            default_field  => [qw( name email )],
+            ( @$_ ? ( fields => $_ ) : () ),
+            croak_on_error => 1,
+        ),
+        'Search::Query::Parser constructed ok'
+    );
+
+    {
+        my $rs_query    = Person->search_rs( $parser->parse('n')->as_dbic_query );
+        my $rs_expected = Person->search_rs(
+            [   \[ "LOWER(name) LIKE ?",  [ plain_value => "%n%" ] ],
+                \[ "LOWER(email) LIKE ?", [ plain_value => "%n%" ] ],
+            ]
+        );
+        eq_resultset( $rs_query, $rs_expected,
+            'one term, default fields, included' );
+    }
+}
+
+done_testing;


### PR DESCRIPTION
Hello.

I have encountered a bug.

It is a thing for the $prefix eq '' has not been taken into account, that the wrong -and and -or.

I added the script reveal the bug.
https://github.com/bokutin/Search-Query-Dialect-DBIxClass/blob/master/eg/bug_prefix.pl

% perl eg/bug_prefix.pl

```
--> Dialect::Native
+(name:o email:o)
--> Dialect::SQL
(name='o' OR email='o')
--> Dialect::DBIxClass
{
  "-and" => [
    {
      "-and" => []
    }
  ]
}
```

% perl -I lib eg/bug_prefix.pl

```
--> Dialect::Native
+(name:o email:o)
--> Dialect::SQL
(name='o' OR email='o')
--> Dialect::DBIxClass
{
  "-and" => [
    {
      "-or" => [
        \[
            "LOWER(name) LIKE ?",
            [
              "plain_value",
              "%o%"
            ]
          ],
        \[
            "LOWER(email) LIKE ?",
            [
              "plain_value",
              "%o%"
            ]
          ]
      ]
    }
  ]
}
```

Please check.

Thank you to merge if it is good.

Cheers,
Tomohiro Hosaka
